### PR TITLE
Adiciona spider para baixar PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
 # Licitações e Contratos de Feira
 
 Uma ferramenta para facilitar o acesso as [licitações realizadas pela
-prefeitura de Feira de Santana](http://www.feiradesantana.ba.gov.br/servicos.asp?id=2&s=a&cat=PMFS&dt=01-2017&link=seadm/licitacoes.asp). 🏦
+prefeitura de Feira de
+Santana](http://www.feiradesantana.ba.gov.br/servicos.asp?id=2&s=a&cat=PMFS&dt=01-2017&link=seadm/licitacoes.asp).
+🏦
+
+## Instalando
+
+Para instalar as dependências você precisa de Python 3 em sua máquina. Execute:
+
+```bash
+pip install -r requirements.txt
+```
+
+Caso queira contribuir desenvolvendo, instale também as dependências de
+desenvolvimento:
+
+```bash
+pip install -r requirements_dev.txt
+```
 
 ## Hora da mágica
 
+### Licitações
+
 Para executar o crawler que busca as licitações:
 
-`scrapy runspider data_collection/bids/crawlers.py -o data_collection/data/bids/bids.json`
+```bash
+scrapy runspider data_collection/bids/crawlers.py -o data_collection/data/bids/bids.json
+```
+
+### FrontEnd
 
 Se quiser executar a aplicação:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Para executar o crawler que busca as licitações:
 scrapy runspider data_collection/bids/crawlers.py -o data_collection/data/bids/bids.json
 ```
 
+### Contratos
+
+```bash
+scrapy runspider data_collection/contracts/list_contracts.py -o data_collection/data/contracts/contracts-pdfs.csv
+```
+
 ### FrontEnd
 
 Se quiser executar a aplicação:

--- a/data_collection/contracts/download_contracts.py
+++ b/data_collection/contracts/download_contracts.py
@@ -1,0 +1,45 @@
+from urllib.parse import urljoin
+from pathlib import Path
+
+import rows
+import scrapy
+
+
+class FeiraSpider(scrapy.Spider):
+    total_pages = 33
+    data = {
+        "POST_PARAMETRO": "PesquisaContratos",
+        "POST_PAGINA": "",
+        "POST_PAGINAS": str(total_pages),
+        "POST_DATA": "",
+        "POST_NMCREDOR": "",
+        "POST_CPFCNPJ": "",
+        "POST_NUCONTRATO": "",
+    }
+    download_path = Path(__file__).parent.parent / "data" / "contracts" / "pdfs"
+    name = "licitacoes-feira"
+    url = "http://www.transparencia.feiradesantana.ba.gov.br/controller/contrato.php"
+
+    def start_requests(self):
+        for page in range(1, self.total_pages + 1):
+            data = self.data.copy()
+            data["POST_PAGINA"] = str(page)
+            yield scrapy.FormRequest(url=self.url, formdata=data)
+
+    def parse(self, response):
+        # TODO: parse other metadata so we can yield together with PDF URL
+        links = rows.plugins.html.extract_links(response.body)
+        for link in links:
+            if not link.lower().endswith(".pdf"):
+                continue
+
+            url = urljoin(self.url, link)
+            yield scrapy.Request(url=url, callback=self.save_pdf, meta={"url": url})
+
+    def save_pdf(self, response):
+        meta = response.request.meta
+        url = meta["url"]
+        filename = self.download_path / Path(url).name
+        with open(filename, mode="wb") as fobj:
+            fobj.write(response.body)
+        yield {"download_path": str(filename), "url": url}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,4 @@
+-r requirements.txt
+black==19.3b0
 ipdb==0.11.0
 pytest==4.3


### PR DESCRIPTION
Em uma próxima etapa podemos já chamar o parser diretamente do spider que baixa os contratos e também extrair mais metadados e/ou passar parâmetros de busca diferentes, para pegar diferentes contratos (por enquanto o número de páginas está fixo).